### PR TITLE
Fix IndexError

### DIFF
--- a/BenchmarkScripts/3d_evaluation/evaluate_semantic_instance.py
+++ b/BenchmarkScripts/3d_evaluation/evaluate_semantic_instance.py
@@ -185,7 +185,7 @@ def evaluate_matches(matches):
 
                     # prepare precision recall
                     num_examples      = len(y_score_sorted)
-                    num_true_examples = y_true_sorted_cumsum[-1]
+                    num_true_examples = y_true_sorted_cumsum[-1] if len(y_true_sorted_cumsum) > 0 else 0
                     precision         = np.zeros(num_prec_recall)
                     recall            = np.zeros(num_prec_recall)
 


### PR DESCRIPTION
There exists one execution path that results in an `IndexError`, this fix solves it. 

Specifically, whenever we evaluate a single scan which contains a match `m` that both `has_gt` and `has_pred`, in which all predictions are non-matched but also all of them are ignored and not counted as FP, then `y_true` and consequently `y_true_sorted_cumsum` are empty arrays.

Then accessing _y_true_sorted_cumsum[-1]_ results in an IndexError.